### PR TITLE
refactor: 상담 결과에서 홀랜드 검사 요약과 진로 추천 데이터로 분리

### DIFF
--- a/src/main/java/com/team/futureway/gemini/dto/AiConsultationSummaryHistoryDTO.java
+++ b/src/main/java/com/team/futureway/gemini/dto/AiConsultationSummaryHistoryDTO.java
@@ -12,11 +12,12 @@ public class AiConsultationSummaryHistoryDTO {
 
     private Long userId;
     private String summary;
+    private String recommend;
     private String userType;
     private LocalDateTime createdDate;
     private List<String> hollandTypes;
 
-    public static AiConsultationSummaryHistoryDTO of(Long userId, String summary, String userType,  LocalDateTime createdDate, List<String> hollandTypes) {
-        return new AiConsultationSummaryHistoryDTO(userId, summary, userType, createdDate, hollandTypes);
+    public static AiConsultationSummaryHistoryDTO of(Long userId, String summary, String recommend, String userType,  LocalDateTime createdDate, List<String> hollandTypes) {
+        return new AiConsultationSummaryHistoryDTO(userId, summary, recommend, userType, createdDate, hollandTypes);
     }
 }

--- a/src/main/java/com/team/futureway/gemini/entity/AiConsultationSummaryHistory.java
+++ b/src/main/java/com/team/futureway/gemini/entity/AiConsultationSummaryHistory.java
@@ -25,11 +25,14 @@ public class AiConsultationSummaryHistory {
     @Column(name = "summary")
     private String summary; // 요약 내용
 
+    @Column(name = "recommend")
+    private String recommend; // 진로 추천 내용
+
     @Column(name = "created_date", nullable = false)
     private LocalDateTime createdDate; // 생성 일자
 
 
-    public static AiConsultationSummaryHistory of(Long aiConsultationSummaryHistoryId, Long userId, String summary) {
-        return new AiConsultationSummaryHistory(aiConsultationSummaryHistoryId, userId, summary, LocalDateTime.now());
+    public static AiConsultationSummaryHistory of(Long aiConsultationSummaryHistoryId, Long userId, String summary, String recommend) {
+        return new AiConsultationSummaryHistory(aiConsultationSummaryHistoryId, userId, summary, recommend, LocalDateTime.now());
     }
 }

--- a/src/main/java/com/team/futureway/gemini/response/SummaryResponse.java
+++ b/src/main/java/com/team/futureway/gemini/response/SummaryResponse.java
@@ -5,8 +5,8 @@ import com.team.futureway.gemini.dto.AiConsultationSummaryHistoryDTO;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record SummaryResponse(Long userId, String summary, String userType, LocalDateTime createdDate, List<String> hollandTypes) {
+public record SummaryResponse(Long userId, String summary, String recommend, String userType, LocalDateTime createdDate, List<String> hollandTypes) {
     public static SummaryResponse of(AiConsultationSummaryHistoryDTO dto) {
-        return new SummaryResponse(dto.getUserId(), dto.getSummary(), dto.getUserType(), dto.getCreatedDate(), dto.getHollandTypes());
+        return new SummaryResponse(dto.getUserId(), dto.getSummary(), dto.getRecommend(), dto.getUserType(), dto.getCreatedDate(), dto.getHollandTypes());
     }
 }

--- a/src/main/java/com/team/futureway/gemini/service/QuestionService.java
+++ b/src/main/java/com/team/futureway/gemini/service/QuestionService.java
@@ -113,9 +113,10 @@ public class QuestionService {
         User user = userRepository.findById(userId).orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND, userId));
 
         // gemini 에게 내용 전달후 상담 결과 요약 받기
-        String summary = geminiService.getNewQuestion(promptUtil.getConsultHistoryPrompt(user.getName(), aiConsultationHistoryList));
+        String summary = geminiService.getNewQuestion(promptUtil.getConsultHistorySummaryPrompt(user.getName(), aiConsultationHistoryList));
+        String recommend = geminiService.getNewQuestion(promptUtil.getRecommendPrompt(user.getName(), summary));
 
-        AiConsultationSummaryHistory aiConsultationSummaryHistory = AiConsultationSummaryHistory.of(null, userId, summary);
+        AiConsultationSummaryHistory aiConsultationSummaryHistory = AiConsultationSummaryHistory.of(null, userId, summary, recommend);
         AiConsultationSummaryHistory result = aiConsultationSummaryHistoryRepository.save(aiConsultationSummaryHistory);
 
         List<String> hollandTypes = extractDataInsideBraces(result.getSummary());
@@ -128,7 +129,7 @@ public class QuestionService {
 
         String cleanedSummary = removeDataInsideBraces(result.getSummary());
 
-        return AiConsultationSummaryHistoryDTO.of(result.getUserId(), cleanedSummary, userType.getUserType(), result.getCreatedDate(), hollandTypes);
+        return AiConsultationSummaryHistoryDTO.of(result.getUserId(), cleanedSummary, recommend, userType.getUserType(), result.getCreatedDate(), hollandTypes);
     }
 
     public List<String> extractHollandTypes(String text) {

--- a/src/main/java/com/team/futureway/gemini/util/PromptUtil.java
+++ b/src/main/java/com/team/futureway/gemini/util/PromptUtil.java
@@ -42,7 +42,7 @@ public class PromptUtil {
             .append("질문은 중복되지 않게 사용자의 답변을 참고해서 진로 탐색을 할 수 있게 질문 작성해줘. ")
             .append("질문이 사용자가 구체적으로 답변할 수 있는 내용이면 더 좋을 것 같아. ")
             .append("만약 답변이 막연하거나 이해하기 어렵다면, 직업 또는 진로 관련 도움을 줄 수 있는 질문을 추천해줘. ")
-            .append("너의 답변이 여러 개가 나올 경우, 가장 연관성 높은 하나만 출력해줘.")
+            .append("너의 답변이 여러 개가 나올 경우, 가장 연관성 높은 하나의 답변만 출력해줘.")
             .append("답변은 글자수 120미만이고 다정하고 따뜻한 어투로 작성해줘.")
             .toString();
     }
@@ -52,19 +52,29 @@ public class PromptUtil {
         return answer;
     }
 
-    public String getConsultHistoryPrompt(String name, List<AiConsultationHistory> consultationHistoryList) {
+    public String getConsultHistorySummaryPrompt(String name, List<AiConsultationHistory> consultationHistoryList) {
         return new StringBuilder()
             .append(extractConsultationHistory(consultationHistoryList))
-            .append(" 중괄호 안에 있는 내용은 " + name + "님의 전공, 경험, 흥미로 진로에 대한 상담을 진행한 내용입니다.")
+            .append(" 중괄호 안에 있는 내용은 " + name + "님의 전공, 경험, 흥미로 진로에 대한 상담을 진행한 내용이야.")
             .append("'현실형' 성격: 솔직하고 성실하며 실용적. 선호: 기계·도구 조작 활동. 능력: 기계적·운동 능력 우수, 대인관계 약함. 가치: 생산성, 전문성. 목표: 기술사, 운동선수. 직업: 기술자, 정비사, 조종사, 농부.")
             .append("'탐구형' 성격: 논리적, 탐구심 강함. 선호: 과학적·창조적 탐구 활동. 능력: 과학·수학 우수, 지도력 부족. 가치: 학문, 지식. 목표: 이론적 발견. 직업: 과학자, 의사, 생물학자.")
             .append("'예술형' 성격: 창의적, 자유분방. 선호: 예술적 표현과 다양성. 능력: 예술적 재능 우수, 사무적 능력 부족. 가치: 창의성, 자유. 목표: 독창적 예술 활동. 직업: 예술가, 작가, 배우.")
             .append("'사회형' 성격: 친절, 봉사적. 선호: 타인 지원과 치료. 능력: 대인관계·지도력 강함, 기계적 능력 약함. 가치: 공익, 헌신. 목표: 사람을 돕는 일. 직업: 교사, 상담가, 간호사.")
             .append("'진취형' 성격: 지도력 강함, 외향적. 선호: 설득·관리 활동. 능력: 사회적·언어 능력 우수, 과학적 능력 부족. 가치: 권력, 명예. 목표: 사회적 지도자. 직업: 정치가, 경영자, 판사.")
             .append("'관습형' 성격: 정확, 책임감 강함. 선호: 자료 조직·정리 활동. 능력: 사무·계산 우수, 창의성 부족. 가치: 안정성, 효율성. 목표: 회계·행정 전문가. 직업: 회계사, 은행원, 경리사.")
-            .append("홀랜드 유형 3개를 중괄호에 담아줘, 그리고 '사용자의 상담 결과 요약 내용', '홀랜드 유형 3개 추천', '추천 진로', '조언 및 계획' 로 구성해서 작성해줘.")
-            .append("답변은 1200자를 초과하지 않도록 하고, 다정하고 따뜻한 어투로 작성해줘.")
+            .append("홀랜드 유형 3개를 중괄호에 담아주고, '홀랜드 유형 3개 추천'을 각각 100자 이내로 구성해서 작성해줘.")
+            .append("마지막에는 '사용자의 상담 결과 요약 내용'을 구성해서 작성해줘.")
+            .append("답변은 520자를 초과하지 않도록 하고, 다정하고 따뜻한 어투로 작성해줘.")
             .toString();
+    }
+
+    public String getRecommendPrompt(String name, String summary) {
+      return new StringBuilder()
+          .append("<" + summary + ">")
+          .append("<> 안에 있는 내용은 " + name + "님의 전공, 경험, 흥미로 진로에 대한 상담을 요약한 내용이야.")
+          .append("'추천 진로', '조언 및 계획' 로 각각 구성해서 작성해줘.")
+          .append("답변은 600자를 초과하지 않도록 하고, 다정하고 따뜻한 어투로 작성해줘.")
+          .toString();
     }
 
 


### PR DESCRIPTION
프론트 엔드에서 상담 결과 데이터를 쉽게 처리할 수 있도록 하기 위해,
홀랜드 검사 결과와 진로 추천 데이터를 구분하여, AI 프롬프트를 생성 및 요청합니다.
상담 결과 API 호출 시, 상담 결과는 summary와 recommand에 나누어 받게 됩니다.