### PR TITLE
feat: 사용자 타입 중복조회 수정 및 명령 프롬프트 개선

### DIFF
--- a/src/main/java/com/team/futureway/gemini/repository/UserTypeRepository.java
+++ b/src/main/java/com/team/futureway/gemini/repository/UserTypeRepository.java
@@ -3,6 +3,9 @@ package com.team.futureway.gemini.repository;
 import com.team.futureway.gemini.entity.UserType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface UserTypeRepository extends JpaRepository<UserType, Long> {
     UserType findByUserId(Long userId);
+
 }

--- a/src/main/java/com/team/futureway/gemini/service/QuestionService.java
+++ b/src/main/java/com/team/futureway/gemini/service/QuestionService.java
@@ -86,7 +86,7 @@ public class QuestionService {
 
     private String generatePrompt(Long userId) {
         List<AiConsultationHistory> historyList = aiConsultationHistoryRepository.findByUserId(userId);
-        String consultationHistory = ""; // promptUtil.extractConsultationHistory(historyList).toString();
+        String consultationHistory = promptUtil.extractConsultationHistory(historyList).toString();
 
         return consultationHistory + promptUtil.getPromptPrefix();
     }
@@ -166,14 +166,24 @@ public class QuestionService {
     }
 
     public UserTypeDTO saveUserType(UserTypeDTO userTypeDTO) {
-        UserType userType = UserType.of(null
-                , userTypeDTO.getUserId()
-                , userTypeDTO.getQuestion()
-                , userTypeDTO.getSelectType()
-                , userTypeDTO.getAnswer()
-                , userTypeDTO.getUserType()
+        UserType existUserType = userTypeRepository.findByUserId(userTypeDTO.getUserId());
+
+        Long userTypeId = null;
+
+        if (existUserType != null) {
+            userTypeId = existUserType.getUserTypeId();
+        }
+
+        UserType userType = UserType.of(userTypeId
+            , userTypeDTO.getUserId()
+            , userTypeDTO.getQuestion()
+            , userTypeDTO.getSelectType()
+            , userTypeDTO.getAnswer()
+            , userTypeDTO.getUserType()
         );
+
         UserType result = userTypeRepository.save(userType);
+
         return userTypeDTO.of(result.getUserId(), result.getQuestion(), result.getSelectType(), result.getAnswer(), result.getUserType());
     }
 


### PR DESCRIPTION
이슈
- 사용자가 상담을 처음부터 다시 시작하거나, 상담 도중 이전 화면으로 돌아가 사용자 유형을 재선택할 경우, 사용자 유형 데이터가 중복 저장되어 N개 이상의 사용자 유형이 조회되는 문제가 발생했습니다. 

수정 
- 사용자 유형 데이터를 저장할 시, 사용자 ID를 기준으로 중복 여부를 체크하여 중복 저장이 발생하지 않도록 수정했습니다.